### PR TITLE
Bugfix: target power assert in ParlAIAllOrderIndependentWrapper

### DIFF
--- a/parlai_diplomacy/wrappers/orders.py
+++ b/parlai_diplomacy/wrappers/orders.py
@@ -1107,7 +1107,8 @@ class ParlAIAllOrderIndependentRolloutWrapper(BaseOrderWrapper):
         A dict of `power` -> `input sequence for model`
         """
         power_to_seq = self._get_input_dict_for_speaker(game, view_of_power)
-        assert target_power is not None
+        if target_power is None:
+            target_power = view_of_power
         assert target_power in power_to_seq
 
         return power_to_seq[target_power]


### PR DESCRIPTION
Fix for bug found by @ML-Chen:
```
  File "/home/ubuntu/diplomacy/diplomacy_cicero/parlai_diplomacy/wrappers/orders.py", line 1110, in _format_input_seq
    assert target_power is not None
AssertionError
```

We never ported this from private branch to release, but we should have.